### PR TITLE
fix: use global isNaN insted of Number.isNaN to support ie11

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -52,7 +52,7 @@ export function isArray(input: any): input is any[] {
  * //=false
  */
 export function isNumber(input: any): input is number {
-  return !Number.isNaN(Number(input)) && input !== null && !isArray(input);
+  return !isNaN(Number(input)) && input !== null && !isArray(input);
 }
 
 /**


### PR DESCRIPTION
ie 11 中使用 Number.isNaN(Number('123')) 报错：对象不支持“isNaN”属性或方法